### PR TITLE
Fix `perl` version in META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -13,7 +13,7 @@
 		"source"  : "git://github.com/drforr/perl6-readline.git"
 	},
 	"source-url"    : "git://github.com/drforr/perl6-readline.git",
-	"perl"          : "v6",
+	"perl"          : "6",
 	"build-depends" : [
 		"LibraryCheck",
 		"panda"


### PR DESCRIPTION
In response to:
```
==> Fetching Readline
Please remove leading 'v' from perl version in Readline's meta info.
==> Building Readline
==> Testing Readline
==> Installing Readline
==> Successfully installed Readline
```

Reference:
http://design.perl6.org/S22.html#META6.json