### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -26,6 +26,6 @@
       "Jeffrey Goff <drforr@pobox.com>"
    ],
    "version" : "0.0.2",
-   "license" : "Artistic",
+   "license" : "Artistic-2.0",
    "description"   : "Perl 6 interface to GNU Readline, the CLI-based line reading library"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license