### PR TITLE
Fix library check on OpenBSD

### DIFF
--- a/lib/Readline.pm
+++ b/lib/Readline.pm
@@ -670,6 +670,7 @@ class Readline:ver<0.1.2> {
     given $*VM.osname {
       when 'openbsd' {
         $library = 'ereadline';
+        $version = v1.0;
         my sub tgetnum(Str --> int32) is native('ncurses') { * }
         tgetnum('');
       }


### PR DESCRIPTION
The version of ereadline on OpenBSD is v1.0, not v7

Fixes #23