### PR TITLE
Load ncurses on Slackware 14.2

### DIFF
--- a/lib/Readline.pm
+++ b/lib/Readline.pm
@@ -711,6 +711,15 @@ class Readline:ver<0.1.4> {
       last;
     }
 
+    given $*DISTRO.name {
+      when 'slackware' {
+        if $version ~~ v6 {
+          my sub tgetnum(Str --> int32) is native('ncurses') { * }
+          tgetnum('');
+        }
+      }
+    }
+
     ( $library, $version )
   }
 


### PR DESCRIPTION
Like OpenBSD, Slackware 14.2 needs to load the ncurses library as described in issue #23.
The upcoming Slackware 15.0 provides readline v7 and does not need a fix.