### PR TITLE
Install readline for different OS

### DIFF
--- a/.rakudist/sparrowfile
+++ b/.rakudist/sparrowfile
@@ -1,4 +1,4 @@
-package-install, %(
+package-install %(
   debian => "libreadline7",
   centos => "readline",
   alpine => "readline"

--- a/.rakudist/sparrowfile
+++ b/.rakudist/sparrowfile
@@ -1,0 +1,5 @@
+package-install, %(
+  debian => "libreadline7",
+  centos => "readline",
+  alpine => "readline"
+);


### PR DESCRIPTION
Hi Jeff! This RakuDist profile could test the modules against different OS/readline packages. You could see example reports here - http://repo.westus.cloudapp.azure.com/rakudist/reports/melezhik/perl6-readline/

